### PR TITLE
stub repository connection test

### DIFF
--- a/movies-service/src/repository/repository.spec.js
+++ b/movies-service/src/repository/repository.spec.js
@@ -7,7 +7,8 @@ const {dbSettings} = require('../config/config')
 
 describe('Repository', () => {
   it('should connect with a promise', () => {
-    repository.connect({}).should.be.a.Promise()
+    const connectionStub = { collection: () => {} }
+    repository.connect(connectionStub).should.be.a.Promise()
   })
 
   it('should get movie premiers', (done) => {


### PR DESCRIPTION
Stub db collection method to prevent error in repository connection
test.

Connect method in `repository.js` throws an error when tested:
```
...

  Repository
    ✓ should connect with a promise
(node:28431) UnhandledPromiseRejectionWarning: TypeError: db.collection is not a function
    at repository (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/src/repository/repository.js:4:25)
    at Promise (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/src/repository/repository.js:84:13)
    at new Promise (<anonymous>)
    at Object.connect (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/src/repository/repository.js:80:10)
    at Context.it (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/src/repository/repository.spec.js:10:16)
    at callFn (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runnable.js:348:21)
    at Test.Runnable.run (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runnable.js:340:7)
    at Runner.runTest (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:443:10)
    at /home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:549:12
    at next (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:361:14)
    at /home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:371:7
    at next (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:295:14)
    at Immediate.<anonymous> (/home/dylan/development/practice/cinema-microservice/cinema-microservice/movies-service/node_modules/mocha/lib/runner.js:339:5)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
(node:28431) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:28431) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

...

  9 passing (665ms)
```
The connect method passes its connection parameter to the repository object. The repository then uses this connection as its db. Because the connect test only passes an empty object, when the repository tries to use `db.collection('movies')` an error is thrown, because `db.collection` is undefined.

My solution is to stub the connection parameter passed to the connect method with a collection method.