### PR TITLE
fix movies integration test description

### DIFF
--- a/movies-service/integration-test/index.js
+++ b/movies-service/integration-test/index.js
@@ -3,7 +3,7 @@ const supertest = require('supertest')
 
 describe('movies-service', () => {
   const api = supertest('http://192.168.99.100:300')
-  it('returns a 200 for a known user', (done) => {
+  it('returns a 200 for a collection of premieres', (done) => {
     api.get('/movies/premieres')
       .expect(200, done)
   })


### PR DESCRIPTION
Change integration test's description from 'users' to 'movie
premieres'.